### PR TITLE
Adicionando instalacao de dependencias no back-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - DB_PORT=3306
       - DB_USERNAME=bn_myapp
       - DB_DATABASE=bitnami_myapp
+    command: "composer install"
     volumes:
       - './backend:/app'
     depends_on:


### PR DESCRIPTION
Ao tentar subir os containers o de back-end não se mantia em pé, nos logs estava disparando uma exception por não encontrar o autoload na vendor justamente por não existir vendor no momento do up.